### PR TITLE
Localization of text

### DIFF
--- a/src/App_Plugins/OpeningSoon/Lang/da-DK.xml
+++ b/src/App_Plugins/OpeningSoon/Lang/da-DK.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+  <area alias="openingsoon">
+    <key alias="monday">Mandag</key>
+    <key alias="tuesday">Tirsdag</key>
+    <key alias="wednesday">Onsdag</key>
+    <key alias="thursday">Torsdag</key>
+    <key alias="friday">Fredag</key>
+    <key alias="saturday">Lørdag</key>
+    <key alias="sunday">Søndag</key>
+    <key alias="until">indtil</key>
+    <key alias="and">og</key>
+    <key alias="notScheduled">ikke angivet</key>
+    <key alias="clearAll">Ryd alt</key>
+    <key alias="autofill">Autofyld</key>
+  </area>
+</language>

--- a/src/App_Plugins/OpeningSoon/Lang/en-GB.xml
+++ b/src/App_Plugins/OpeningSoon/Lang/en-GB.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+  <area alias="openingsoon">
+    <key alias="monday">Monday</key>
+    <key alias="tuesday">Tuesday</key>
+    <key alias="wednesday">Wednesday</key>
+    <key alias="thursday">Thursday</key>
+    <key alias="friday">Friday</key>
+    <key alias="saturday">Saturday</key>
+    <key alias="sunday">Sunday</key>
+    <key alias="until">until</key>
+    <key alias="and">and</key>
+    <key alias="notScheduled">not scheduled</key>
+    <key alias="clearAll">Clear all</key>
+    <key alias="autofill">Autofill</key>
+  </area>
+</language>

--- a/src/App_Plugins/OpeningSoon/Lang/en-US.xml
+++ b/src/App_Plugins/OpeningSoon/Lang/en-US.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+  <area alias="openingsoon">
+    <key alias="monday">Monday</key>
+    <key alias="tuesday">Tuesday</key>
+    <key alias="wednesday">Wednesday</key>
+    <key alias="thursday">Thursday</key>
+    <key alias="friday">Friday</key>
+    <key alias="saturday">Saturday</key>
+    <key alias="sunday">Sunday</key>
+    <key alias="until">until</key>
+    <key alias="and">and</key>
+    <key alias="notScheduled">not scheduled</key>
+    <key alias="clearAll">Clear all</key>
+    <key alias="autofill">Autofill</key>
+  </area>
+</language>

--- a/src/App_Plugins/OpeningSoon/OpeningSoon.Controller.js
+++ b/src/App_Plugins/OpeningSoon/OpeningSoon.Controller.js
@@ -1,9 +1,9 @@
 angular.module("umbraco")
 	.controller("Jumoo.OpeningSoonController", 
-	function($scope, assetsService) {
+	function($scope, assetsService, localizationService) {
 	
 		assetsService.loadCss("/App_Plugins/OpeningSoon/Scripts/jquery.timepicker.css");
-	
+		
 		$scope.resetDays = function()
 		{
 			$scope.model.value = [
@@ -14,7 +14,15 @@ angular.module("umbraco")
 				{ 'name': 'Friday',   'scheduled': true, 'open': '',  'close' : '' },
 				{ 'name': 'Saturday', 'scheduled': true, 'open': '',  'close' : '' },
 				{ 'name': 'Sunday',   'scheduled': true, 'open': '',  'close' : '' }
-			]; 
+			];
+
+			$scope.model.value[0].name = localizationService.dictionary['openingsoon_monday'] || $scope.model.value[0].name;
+			$scope.model.value[1].name = localizationService.dictionary['openingsoon_tuesday'] || $scope.model.value[1].name;
+			$scope.model.value[2].name = localizationService.dictionary['openingsoon_wednesday'] || $scope.model.value[2].name;
+			$scope.model.value[3].name = localizationService.dictionary['openingsoon_thursday'] || $scope.model.value[3].name;
+			$scope.model.value[4].name = localizationService.dictionary['openingsoon_friday'] || $scope.model.value[4].name;
+			$scope.model.value[5].name = localizationService.dictionary['openingsoon_saturday'] || $scope.model.value[5].name;
+			$scope.model.value[6].name = localizationService.dictionary['openingsoon_sunday'] || $scope.model.value[6].name;
 		}
 
 		if ( !$scope.model.value ) { $scope.resetDays() ; }
@@ -57,8 +65,8 @@ angular.module("umbraco")
 					scope.$apply(function() {
 						var mytime = element.timepicker('getTime', new Date());
 						var timestring = 
-							("0" + mytime.getHours()).substr(-2,2) + ":" + 
-							("0" + mytime.getMinutes()).substr(-2,2) ; 
+							("0" + (mytime != null ? mytime.getHours() : "0")).substr(-2,2) + ":" + 
+							("0" + (mytime != null ? mytime.getMinutes() : "0")).substr(-2,2) ; 
 						controller.$setViewValue(timestring);
 						});
 				});

--- a/src/App_Plugins/OpeningSoon/openingsoon.css
+++ b/src/App_Plugins/OpeningSoon/openingsoon.css
@@ -1,7 +1,25 @@
- input.jumoo-opening-time {
+input.jumoo-opening-time {
 	width: 60px;
 }
 
 tr.jumoo-opening-entry {
 	height: 40px;
-} 
+}
+
+tr.jumoo-opening-entry td span.jumoo-inline-label {
+	display: inline-block;
+	padding-top: 5px;
+}
+
+tr.jumoo-opening-entry td.jumoo-opening-notscheduled {
+	color: #888;
+}
+
+tr.jumoo-opening-entry td:nth-child(2) {
+	padding-left: 5px;
+	padding-right: 5px;
+}
+
+.table-jumoo-opening tfoot > tr > td {
+	padding-top: 10px;
+}

--- a/src/App_Plugins/OpeningSoon/openingsoon.html
+++ b/src/App_Plugins/OpeningSoon/openingsoon.html
@@ -1,33 +1,37 @@
 <div ng-controller="Jumoo.OpeningSoonController">
 
-	<table ng-model="model.value">
-		<tr ng-repeat="day in model.value" class="jumoo-opening-entry">
-			<td>{{day.name}}</td>
-			<td><input type="checkbox" ng-model="day.scheduled"></td>
-			<td ng-show="day.scheduled">
-				<input type="text" time-picker ng-model="day.open" class="jumoo-opening-time">
-				until 
-				<input type="text" time-picker ng-model="day.close" class="jumoo-opening-time">
-			</td>
-			<td ng-show="!day.scheduled">
-				not scheduled
-			</td>
-			
-			<td ng-show="model.config.SecondSet != 0 && day.scheduled"> and </td>
-			<td ng-show="model.config.SecondSet != 0 && day.scheduled">
-				<input type="text" time-picker ng-model="day.open2" class="jumoo-opening-time">
-				until 
-				<input type="text" time-picker ng-model="day.close2" class="jumoo-opening-time">
-			</td>
-			</div>
-		</tr>
-		
-		<tr>
-			<td colspan="4">
-				<a ng-show="model.config.enableClear" ng-click="clearAll()" class="btn">clear all</a>
-				<a ng-show="model.config.enableAutofill" ng-click="autofill()" class="btn">Autofill</a>
-			</td>
-		</tr>
-		
+	<table ng-model="model.value" class="table-jumoo-opening">
+		<tbody>
+			<tr ng-repeat="day in model.value" class="jumoo-opening-entry">
+				<td>{{day.name}}</td>
+				<td><input type="checkbox" id="day-{{$index + 1}}" ng-model="day.scheduled"></td>
+				
+				<td ng-show="day.scheduled">
+					<input type="text" time-picker ng-model="day.open" class="jumoo-opening-time">
+					<span class="jumoo-inline-label"><localize key="openingsoon_until">until</localize></span>
+					<input type="text" time-picker ng-model="day.close" class="jumoo-opening-time">
+				</td>
+				<td ng-show="!day.scheduled" class="jumoo-opening-notscheduled">
+					<localize key="openingsoon_notScheduled">not scheduled</localize>
+				</td>
+				
+				<td ng-show="model.config.SecondSet != 0 && day.scheduled"> <localize key="openingsoon_and">and</localize> </td>
+				<td ng-show="model.config.SecondSet != 0 && day.scheduled">
+					<input type="text" time-picker ng-model="day.open2" class="jumoo-opening-time">
+					<span class="jumoo-inline-label"><localize key="openingsoon_until">until</localize></span>
+					<input type="text" time-picker ng-model="day.close2" class="jumoo-opening-time">
+				</td>
+				</div>
+			</tr>
+		</tbody>
+		<tfoot>
+			<tr>
+				<td colspan="2"></td>
+				<td>
+					<a ng-show="model.config.enableClear" ng-click="clearAll()" class="btn"><localize key="openingsoon_clearAll">clear all</localize></a>
+					<a ng-show="model.config.enableAutofill" ng-click="autofill()" class="btn"><localize key="openingsoon_autofill">Autofill</localize></a>
+				</td>
+			</tr>
+		</tfoot>
 	</table>
 </div>


### PR DESCRIPTION
Localization of text and small changed in styling. Fix for #1 

I have used the ```localizationService``` to get the keys from /Umbraco/Config/Lang with the simple syntax ```localizationService.dictionary['area_key']```.
It can also be used like the following:

```
localizationService.localize(str)
    .always(function(response) {
        console.log("[" + str + "]");
    })
    .then(function (value) {
        var text = value != null ? value : "";
        console.log(text);
    });
```

Futhermore I have prepared for Umbraco 7.3.0, where it will be possible to ship language files with the package: http://issues.umbraco.org/issue/U4-5777 ... for now just add the keys from the languages files to the core Umbraco file. Another approach is to use a package action like this https://github.com/warrenbuckley/Analytics/blob/develop/Analytics/InstallHelpers.cs#L20 to insert the language keys into the core language files.

Finally a have modified the styles a bit and I noticed a console error sometimes happened because ```mytime``` object sometimes was null.


![image](https://cloud.githubusercontent.com/assets/2919859/8172010/d61d7f62-13bc-11e5-86e8-4b6ec16918eb.png)